### PR TITLE
Resolve issue with incorrect url for remote CSS when using addCssUrl, an...

### DIFF
--- a/lib/css.coffee
+++ b/lib/css.coffee
@@ -29,7 +29,8 @@ class Css extends Bundle
     style = ''
     for file in @files
       if file.namespace == namespace
-        style += "<link href='#{file.url}' rel='stylesheet' type='text/css'/>"
+        url = if typeof file.url == 'boolean' then file.file else file.url
+        style += "<link href='#{url}' rel='stylesheet' type='text/css'/>"
     return style
 
   _convertFilename: (filename) ->


### PR DESCRIPTION
...d bundle option is false.  This results from the file.url property being a boolean value instead of a string, and the result is the link tag is output as <link href='true' /> rather than with the correct url.  Looks like this was already fixed for JS files, but not CSS.
